### PR TITLE
FIx obs_shape usage in VIP forward()

### DIFF
--- a/vip/models/model_vip.py
+++ b/vip/models/model_vip.py
@@ -65,10 +65,10 @@ class VIP(nn.Module):
         self.encoder_opt = torch.optim.Adam(params, lr = lr)
 
     ## Forward Call (im --> representation)
-    def forward(self, obs, obs_shape = [3, 224, 224]):
+    def forward(self, obs):
         obs_shape = obs.shape[1:]
         # if not already resized and cropped, then add those in preprocessing
-        if obs_shape != [3, 224, 224]:
+        if obs_shape != (3, 224, 224):
             preprocess = nn.Sequential(
                         transforms.Resize(256),
                         transforms.CenterCrop(224),


### PR DESCRIPTION
The purpose of this PR is to fix a small bug in VIP's `forward()` function. The two problems are:

1. The `obs_shape` argument is not used, as it is immediately overwritten by `obs_shape = obs.shape[1:]`
2. The `obs_shape` type is a torch.Size, which is never equal to a list. Thus, even if the obs_shape is torch.Size([3, 224, 224]), `obs_shape != [3, 224, 224]` will always evaluate to be True. This means the wrong preprocessing step is run.

Possible solutions:
1. Remove the line `obs_shape = obs.shape[1:]` (as done in this PR, similar to https://github.com/facebookresearch/r3m/blob/main/r3m/models/models_r3m.py#L84)
2. Convert the obs_shape to a list with `obs_shape = list(obs.shape[1:])` instead of `obs_shape = obs.shape[1:]` (another reasonable solution) or make it (3, 224, 224) instead of [3, 224, 224]